### PR TITLE
Refactor upvote/downvote status

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,7 +5,7 @@ function CardElements(title, body) {
   this.title = title;
   this.body = body;
   this.id = Date.now();
-  this.quality = 'swill';
+  this.quality = 0;
 };
 
 $(window).on('load', function() {
@@ -30,45 +30,77 @@ $('.idea-card-parent').on('click', '#delete', function() {
   $(this).parents('.idea-card').remove()
 });
 
+// UPVOTE AND DOWN BUTTONS THAT COMMUNITCATE CHANGE TO STORAGE
 $('.idea-card-parent').on('click', '#upvote', function(event) {
   event.preventDefault();
-  var cardId = $(this).closest('.idea-card')[0].id
+  var cardId = parseInt($(this).closest('.idea-card')[0].id);
+  var status = ["swill", "plausible", "genius"];
   cardArray.forEach(function(card) {
-    if (card.id == cardId) {
-      if (card.quality === "swill") {
-        card.quality = "plausible";
-        $('.' + cardId).text('plausible')
-      } else if (card.quality === "plausible") {
-        card.quality = "genius"
-        $('.' + cardId).text('genius')
-      } else {
-        card.quality = "genius"
-        $('.' + cardId).text('genius')
-      }
+      if (card.id === cardId) {
+      card.quality++;
+      console.log('status', status[card.quality]);
+      $('.new-quality').text(status[card.quality])
     }
     storeCards();
-  })
+    });
 });
 
-$('.idea-card-parent').on('click', '#downvote', function (event){
+
+
+$('.idea-card-parent').on('click', '#downvote', function(event) {
   event.preventDefault();
-  var cardId = $(this).closest('.idea-card')[0].id
-  cardArray.forEach(function (card) {
-  if (card.id == cardId) {
-    if (card.quality === 'genius') {
-        card.quality = 'plausible';
-        $('.' + cardId).text('plausible')
-      } else if (card.quality === 'plausible') {
-        card.quality = 'swill'
-        $('.' + cardId).text('swill')
-      }else{
-        card.quality = 'swill'
-        $('.' + cardId).text('swill')
-      }
-  }
-  storeCards();
-})
+  var cardId = parseInt($(this).closest('.idea-card')[0].id);
+  var status = ["swill", "plausible", "genius"];
+  cardArray.forEach(function(card) {
+      if (card.id === cardId) {
+      card.quality--;
+      console.log('status', status[card.quality]);
+      $('.new-quality').text(status[card.quality])
+    }
+    storeCards();
+    });
 });
+
+// ORIGINAL UPVOTE AND DOWNVOTE BUTTONS
+// $('.idea-card-parent').on('click', '#upvote', function(event) {
+//   event.preventDefault();
+//   var cardId = $(this).closest('.idea-card')[0].id
+//   cardArray.forEach(function(card) {
+//     if (card.id == cardId) {
+//       if (card.quality === "swill") {
+//         card.quality = "plausible";
+//         $('.' + cardId).text('plausible')
+//       } else if (card.quality === "plausible") {
+//         card.quality = "genius"
+//         $('.' + cardId).text('genius')
+//       } else {
+//         card.quality = "genius"
+//         $('.' + cardId).text('genius')
+//       }
+//     }
+//     storeCards();
+//   })
+// });
+
+// $('.idea-card-parent').on('click', '#downvote', function (event){
+//   event.preventDefault();
+//   var cardId = $(this).closest('.idea-card')[0].id
+//   cardArray.forEach(function (card) {
+//   if (card.id == cardId) {
+//     if (card.quality === 'genius') {
+//         card.quality = 'plausible';
+//         $('.' + cardId).text('plausible')
+//       } else if (card.quality === 'plausible') {
+//         card.quality = 'swill'
+//         $('.' + cardId).text('swill')
+//       }else{
+//         card.quality = 'swill'
+//         $('.' + cardId).text('swill')
+//       }
+//   }
+//   storeCards();
+// })
+// });
 
 $('.save-btn').on('click', function(event) {
   event.preventDefault();
@@ -131,7 +163,7 @@ function addCards(buildCard) {
       <div class="ratings">
       <div class="upvote-btn" id="upvote"></div>
       <div class="downvote-btn" id="downvote"></div>
-        <p class="quality">quality: <span class="${buildCard.id}">${buildCard.quality}</span></p>
+        <p class="quality">quality: <span class="${buildCard.id} new-quality">${buildCard.quality}</span></p>
       </div>
       <hr>
     </article>`);


### PR DESCRIPTION
Removed if/else statues from upvote/downvote buttons to instead pull new statements form an array. Using increment and decrement counters to modify the index number of which status in the array applies to the card in question.

The original functions are below the new functions, commented out.